### PR TITLE
remove schnorr method

### DIFF
--- a/src/network/jsonrpc.ts
+++ b/src/network/jsonrpc.ts
@@ -52,7 +52,7 @@ export const getBlock = async (blockNumber: number) => {
 
 export const generateAddress = () => {
   const privKey = secp.utils.randomPrivateKey();
-  const pubKey = secp.schnorr.getPublicKey(privKey);
+  const pubKey = secp.getPublicKey(privKey);
 
   const slicedKey = pubKey.slice(1);
   const hashKey = keccak_256(slicedKey);


### PR DESCRIPTION
schnorr로 생성된 publickey 제거

secp256k1의 기본 방식을 사용하도록 변경함